### PR TITLE
Fix disabling code signing on latest VS for Mac, add touch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 - Visual Studio for Mac with the C#, .NET and Xamarin.iOS workloads
 - patience
 
-## caveats
-- no touch support - you *need* a keyboard to play (if you want to implement touch support, feel free to make a PR!)
-
 ## how to build
 - install the needed software mentioned above
 - run `./build.sh`

--- a/build.sh
+++ b/build.sh
@@ -353,7 +353,7 @@ if ! ./buildlibs.sh ios; then nativelib_build_err; fi
 if ! cp -r "$script_dir/fnalibs-ios-builder-celeste/release/ios/device/." "$script_dir/celestemeow/"; then nativelib_build_err; fi
 
 cd "$script_dir" || cd_fail
-if ! msbuild /restore /p:Configuration="AppStore" /p:"Configuration=Release;Platform=iPhone" /target:celestemeow; then
+if ! msbuild /restore /p:Configuration="AppStore" /p:"Configuration=Release;Platform=iPhone" /target:celestemeow /p:EnableCodeSigning=false; then
 	error "failed to build ios project"
 	exit 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -349,6 +349,19 @@ nativelib_build_err() {
 }
 
 if ! ./updatelibs.sh; then nativelib_build_err; fi
+while true; do
+	read -p "Do you want to enable a virtual game controller if no other input devices are detected? iOS 15+ only! (y/n) " yn
+	case $yn in
+		[Yy]* )
+			cd "$script_dir/fnalibs-ios-builder-celeste/SDL2" || cd_fail
+			apply_patch "$script_dir/patches/SDL-gamecontroller.patch"
+			cd "$script_dir/fnalibs-ios-builder-celeste" || cd_fail
+			break;;
+		[Nn]* )
+			break;;
+		* ) echo "Please answer y/n." ;;
+	esac
+done
 if ! ./buildlibs.sh ios; then nativelib_build_err; fi
 if ! cp -r "$script_dir/fnalibs-ios-builder-celeste/release/ios/device/." "$script_dir/celestemeow/"; then nativelib_build_err; fi
 

--- a/celestemeow/celestemeow.csproj
+++ b/celestemeow/celestemeow.csproj
@@ -66,7 +66,7 @@
         <MtouchDebug>true</MtouchDebug>
         <CreatePackage>true</CreatePackage>
         <BuildIpa>true</BuildIpa>
-        <MtouchExtraArgs>-cxx -gcc_flags "-L${ProjectDir} -lSDL2 -lFNA3D -lFAudio -ltheorafile -lMoltenVK -force_load ${ProjectDir}/libSDL2.a -force_load ${ProjectDir}/libFNA3D.a -force_load ${ProjectDir}/libFAudio.a -force_load ${ProjectDir}/libtheorafile.a -force_load ${ProjectDir}/libMoltenVK.a -framework AVFoundation -framework AudioToolbox -framework CoreGraphics -framework Metal -framework QuartzCore -framework OpenGLES -framework GameController -framework CoreMotion -framework MobileCoreServices -framework ImageIO -framework CoreHaptics -framework CoreBluetooth -framework IOSurface -lfmod -force_load ${ProjectDir}/libfmod.a -lfmodstudio -force_load ${ProjectDir}/libfmodstudio.a" -v</MtouchExtraArgs>
+        <MtouchExtraArgs>-cxx -gcc_flags "-L${ProjectDir} -lSDL2 -lFNA3D -ltheorafile -lMoltenVK -force_load ${ProjectDir}/libSDL2.a -force_load ${ProjectDir}/libFNA3D.a -force_load ${ProjectDir}/libtheorafile.a -force_load ${ProjectDir}/libMoltenVK.a -framework AVFoundation -framework AudioToolbox -framework CoreGraphics -framework Metal -framework QuartzCore -framework OpenGLES -framework GameController -framework CoreMotion -framework MobileCoreServices -framework ImageIO -framework CoreHaptics -framework CoreBluetooth -framework IOSurface -lfmod -force_load ${ProjectDir}/libfmod.a -lfmodstudio -force_load ${ProjectDir}/libfmodstudio.a" -v</MtouchExtraArgs>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
       <DebugSymbols>true</DebugSymbols>
@@ -82,7 +82,7 @@
         <CreatePackage>true</CreatePackage>
         <CodesignProvision></CodesignProvision>
         <BuildIpa>true</BuildIpa>
-        <MtouchExtraArgs>-cxx -gcc_flags "-L${ProjectDir} -lSDL2 -lFNA3D -lFAudio -lMoltenVK -force_load ${ProjectDir}/libSDL2.a -force_load ${ProjectDir}/libFNA3D.a -force_load ${ProjectDir}/libFAudio.a -force_load ${ProjectDir}/libMoltenVK.a -framework AVFoundation -framework AudioToolbox -framework CoreGraphics -framework Metal -framework QuartzCore -framework OpenGLES -framework GameController -framework CoreMotion -framework MobileCoreServices -framework ImageIO -framework CoreHaptics -framework CoreBluetooth -framework IOSurface -lfmod -force_load ${ProjectDir}/libfmod.a -lfmodstudio -force_load ${ProjectDir}/libfmodstudio.a" -v</MtouchExtraArgs>
+        <MtouchExtraArgs>-cxx -gcc_flags "-L${ProjectDir} -lSDL2 -lFNA3D -lMoltenVK -force_load ${ProjectDir}/libSDL2.a -force_load ${ProjectDir}/libFNA3D.a -force_load ${ProjectDir}/libMoltenVK.a -framework AVFoundation -framework AudioToolbox -framework CoreGraphics -framework Metal -framework QuartzCore -framework OpenGLES -framework GameController -framework CoreMotion -framework MobileCoreServices -framework ImageIO -framework CoreHaptics -framework CoreBluetooth -framework IOSurface -lfmod -force_load ${ProjectDir}/libfmod.a -lfmodstudio -force_load ${ProjectDir}/libfmodstudio.a" -v</MtouchExtraArgs>
         <MtouchLink>SdkOnly</MtouchLink>
         <MtouchInterpreter>-all</MtouchInterpreter>
         <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>

--- a/celestemeow/celestemeow.csproj
+++ b/celestemeow/celestemeow.csproj
@@ -179,19 +179,6 @@
         <Compile Include="Main.cs" />
     </ItemGroup>
     <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-    <Target Name="Codesign" />
-     	<Target Name="_DetectSigningIdentity" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_DetectAppManifest;_DetectSdkLocations;_ComputeTargetFrameworkMoniker">
-   	<DetectSigningIdentity SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" AppBundleName="$(_AppBundleName)" AppManifest="$(_AppManifest)" RequireCodeSigning="false" RequireProvisioningProfile="false" SdkIsSimulator="$(_SdkIsSimulator)" SdkPlatform="$(_SdkPlatform)" TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)">
-
-   		<Output TaskParameter="DetectedAppId" PropertyName="_AppIdentifier" />
-   		<Output TaskParameter="DetectedBundleId" PropertyName="_BundleIdentifier" />
-   		<Output TaskParameter="DetectedBundleVersion" PropertyName="_BundleVersion" />
-   		<Output TaskParameter="DetectedCodeSigningKey" PropertyName="_CodeSigningKey" />
-   		<Output TaskParameter="DetectedCodesignAllocate" PropertyName="_CodesignAllocate" />
-   		<Output TaskParameter="DetectedDistributionType" PropertyName="_DistributionType" />
-   		<Output TaskParameter="DetectedProvisioningProfile" PropertyName="_ProvisioningProfile" />
-   	</DetectSigningIdentity>
-   </Target>
    <!-- <Target Name="IncludeAllFilesInTargetDir" AfterTargets="Build">
   <ItemGroup>
     <Folder Include="./../celeste" />

--- a/patches/SDL-gamecontroller.patch
+++ b/patches/SDL-gamecontroller.patch
@@ -1,0 +1,40 @@
+diff --git a/src/video/uikit/SDL_uikitmetalview.m b/src/video/uikit/SDL_uikitmetalview.m
+index 8274eaff9..04887a0d0 100644
+--- a/src/video/uikit/SDL_uikitmetalview.m
++++ b/src/video/uikit/SDL_uikitmetalview.m
+@@ -35,7 +35,9 @@
+ 
+ #import "SDL_uikitwindow.h"
+ #import "SDL_uikitmetalview.h"
++#import <GameController/GameController.h>
+ 
++GCVirtualController *CONTROLLER = NULL;
+ 
+ @implementation SDL_uikitmetalview
+ 
+@@ -54,6 +56,25 @@ - (instancetype)initWithFrame:(CGRect)frame
+         [self updateDrawableSize];
+     }
+ 
++    if ([GCController controllers].count == 0 && ![GCKeyboard coalescedKeyboard]) {
++        if (!CONTROLLER) {
++            GCVirtualControllerConfiguration *configuration = [GCVirtualControllerConfiguration new];
++            configuration.elements = [NSSet setWithArray:@[
++                GCInputButtonA,
++                GCInputButtonB,
++                GCInputButtonX,
++                GCInputButtonY,
++                GCInputRightTrigger,
++                GCInputLeftTrigger,
++                GCInputRightShoulder,
++                GCInputLeftShoulder,
++                GCInputLeftThumbstick
++            ]];
++            CONTROLLER = [GCVirtualController virtualControllerWithConfiguration:configuration];
++        }
++        [CONTROLLER connectWithReplyHandler:NULL];
++    }
++
+     return self;
+ }
+ 

--- a/patches/SDL-gamecontroller.patch
+++ b/patches/SDL-gamecontroller.patch
@@ -16,7 +16,7 @@ index 8274eaff9..04887a0d0 100644
          [self updateDrawableSize];
      }
  
-+    if ([GCController controllers].count == 0 && ![GCKeyboard coalescedKeyboard]) {
++    if (@available(iOS 15, *) && [GCController controllers].count == 0 && ![GCKeyboard coalescedKeyboard]) {
 +        if (!CONTROLLER) {
 +            GCVirtualControllerConfiguration *configuration = [GCVirtualControllerConfiguration new];
 +            configuration.elements = [NSSet setWithArray:@[


### PR DESCRIPTION
This fixes disabling code signing on the latest visual studio for mac. Combined with [the fnalibs-ios-builder-celeste PR](https://github.com/RoootTheFox/fnalibs-ios-builder-celeste/pull/1), builds should now work on latest macos/xcode/visual studio for mac.