### PR TITLE
enable proper fullscreen rendering on iPhones (fix #2)

### DIFF
--- a/celestemeow/Info.plist
+++ b/celestemeow/Info.plist
@@ -49,5 +49,22 @@
 	<array>
 		<string>processing</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleHidden</string>
+	<key>UIFullScreen</key>
+	<true />
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false />
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false />
+		<key>UISceneConfigurations</key>
+		<dict />
+	</dict>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR includes a few changes in the `Info.plist` fixing issues outlined in #2 - enabling real, proper fullscreen without black bars at the top and bottom on iPhones (tested on iPhone 15 Pro with iOS 18.3.1). 

![IMG_0928](https://github.com/user-attachments/assets/6c015c24-76a9-4a72-a5bd-a16ce64d94d2)

![IMG_0929](https://github.com/user-attachments/assets/3a743f39-bcae-4acc-b092-414810bc7d1c)
