### PR TITLE
move saves to documents directory (visible in files app) (fix #11)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -355,9 +355,13 @@ while true; do
 		[Yy]* )
 			cd "$script_dir/fnalibs-ios-builder-celeste/SDL2" || cd_fail
 			apply_patch "$script_dir/patches/SDL-gamecontroller.patch"
+			apply_patch "$script_dir/patches/ios-save-files.patch"
 			cd "$script_dir/fnalibs-ios-builder-celeste" || cd_fail
 			break;;
 		[Nn]* )
+			cd "$script_dir/fnalibs-ios-builder-celeste/SDL2" || cd_fail
+			apply_patch "$script_dir/patches/ios-save-files.patch"
+			cd "$script_dir/fnalibs-ios-builder-celeste" || cd_fail
 			break;;
 		* ) echo "Please answer y/n." ;;
 	esac

--- a/celestemeow/Info.plist
+++ b/celestemeow/Info.plist
@@ -49,5 +49,22 @@
 	<array>
 		<string>processing</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleHidden</string>
+	<key>UIFullScreen</key>
+	<true />
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false />
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false />
+		<key>UISceneConfigurations</key>
+		<dict />
+	</dict>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 </dict>
 </plist>

--- a/celestemeow/Info.plist
+++ b/celestemeow/Info.plist
@@ -66,5 +66,9 @@
 	</dict>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
+	<key>UIFileSharingEnabled</key>
+	<true />
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true />
 </dict>
 </plist>

--- a/patches/ios-save-files.patch
+++ b/patches/ios-save-files.patch
@@ -1,0 +1,30 @@
+diff --git a/src/filesystem/cocoa/SDL_sysfilesystem.m b/src/filesystem/cocoa/SDL_sysfilesystem.m
+index 87b8f9c..d4e8f9c 100644
+--- a/src/filesystem/cocoa/SDL_sysfilesystem.m
++++ b/src/filesystem/cocoa/SDL_sysfilesystem.m
+@@ -87,7 +87,7 @@ SDL_GetPrefPath(const char *org, const char *app)
+     }
+ 
+ #if !TARGET_OS_TV
+-    array = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
++    array = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+ #else
+     /* tvOS does not have persistent local storage!
+      * The only place on-device where we can store data is
+     * a cache directory that the OS can empty at any time.
+     *
+     * It's therefore very likely that save data will be erased
+     * between sessions. If you want your app's save data to
+     * actually stick around, you'll need to use iCloud storage.
+     */
+    {
+        static SDL_bool shown = SDL_FALSE;
+        if (!shown)
+        {
+            shown = SDL_TRUE;
+            SDL_LogCritical(SDL_LOG_CATEGORY_SYSTEM, "tvOS does not have persistent local storage! Use iCloud storage if you want your data to persist between sessions.\n");
+        }
+    }
+
+    array = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+#endif /* !TARGET_OS_TV */


### PR DESCRIPTION
this PR includes patches to move all content saved by Celeste into the `Documents` directory, which is accessible via files app and has some other perks:
* included in device backups by default
* protected from being cleared when the device is low on storage

Confirmed working on iPhone 15 Pro running iOS 18.3.1:
![IMG_0931](https://github.com/user-attachments/assets/da19bfe5-0c6b-4ec3-9689-5025047c672a)


This should close issue #11.